### PR TITLE
Add configurable routes with infobox notifications and GPS

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -2,10 +2,14 @@ local panelVisible = false
 local routes = {}
 local selectedRoute = nil
 
+local function outputMessage(mess, tipo)
+    return exports['[HS]Notify_System']:notify(mess, tipo)
+end
+
 local screenW, screenH = guiGetScreenSize()
-local panelW, panelH = 400, 300
+local panelW, panelH = 500, 350
 local panelX, panelY = (screenW-panelW)/2, (screenH-panelH)/2
-local startBtn = {x = panelX + 100, y = panelY + panelH - 50, w = 200, h = 40}
+local startBtn = {x = panelX + 150, y = panelY + panelH - 60, w = 200, h = 40}
 
 addEvent("carroforte:openPanel", true)
 addEventHandler("carroforte:openPanel", resourceRoot, function(serverRoutes)
@@ -46,7 +50,7 @@ addEventHandler("onClientClick", root, function(button, state, x, y)
             panelVisible = false
             showCursor(false)
         else
-            outputChatBox("Selecione uma rota primeiro", 255, 0, 0)
+            outputMessage("Selecione uma rota primeiro", "error")
         end
     end
 end)

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,25 @@
+local CONFIG = {
+    startPositions = {
+        {pos = {1552, -1675, 16}, size = 2.0, rgb = {255, 255, 0, 150}},
+    },
+    routes = {
+        {
+            name = "Los Santos para Las Venturas",
+            vehicleSpawn = {1540, -1685, 13, 0},
+            markers = {
+                {pos = {2320, 1289, 10}, recompensa = {5000, 6000}},
+                {pos = {2335, 1300, 10}, recompensa = {5000, 6000}},
+            }
+        },
+        {
+            name = "San Fierro para Los Santos",
+            vehicleSpawn = {1540, -1685, 13, 0},
+            markers = {
+                {pos = {-2032, 500, 35}, recompensa = {6000, 7000}},
+                {pos = {-2020, 470, 35}, recompensa = {6000, 7000}},
+            }
+        }
+    }
+}
+
+return CONFIG

--- a/meta.xml
+++ b/meta.xml
@@ -1,5 +1,7 @@
 <meta>
     <info author="ChatGPT" type="script" name="Carro Forte Job" />
+    <script src="config.lua" type="server" />
     <script src="server.lua" type="server" />
     <script src="client.lua" type="client" />
+    <export function="set_gps" type="server" />
 </meta>


### PR DESCRIPTION
## Summary
- make routes configurable via new config.lua
- use infobox notifications and GPS blips for deliveries
- enlarge client route panel for better visibility

## Testing
- `luac -p server.lua client.lua config.lua`


------
https://chatgpt.com/codex/tasks/task_e_688cfa968c9483329cabf08fa79b7de2