### PR TITLE
Fix Carro Forte config and require end-of-route return

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -1,4 +1,5 @@
-local CONFIG = {
+-- Global configuration accessible by other scripts
+CONFIG = {
     startPositions = {
         {pos = {1552, -1675, 16}, size = 2.0, rgb = {255, 255, 0, 150}},
     },
@@ -21,5 +22,3 @@ local CONFIG = {
         }
     }
 }
-
-return CONFIG


### PR DESCRIPTION
## Summary
- load config.lua as a global instead of using unsafe require
- require players to return to the start blip and use `/finalrota` after final delivery

## Testing
- `luac -p server.lua config.lua`


------
https://chatgpt.com/codex/tasks/task_e_688cfeeca7bc8332a1fa5001cb4cdee3